### PR TITLE
Promote hello-api to cand

### DIFF
--- a/argocd/cand/candidate-fra/hello-api/values-image.yaml
+++ b/argocd/cand/candidate-fra/hello-api/values-image.yaml
@@ -1,5 +1,5 @@
 base:
   image:
     repository: ghcr.io/dbeilin-playground/hello-api
-    tag: v1.0.20250904090830-59b4afe
+    tag: v1.0.20250904132853-d858e12
     pullPolicy: Always


### PR DESCRIPTION
Promote hello-api to cand


[View in Kargo UI](https://localhost/project/kargo-savvy/stage/hello-api-cand)