### PR TITLE
Promote nginx to cand

### DIFF
--- a/argocd/cand/candidate-fra/nginx/values-image.yaml
+++ b/argocd/cand/candidate-fra/nginx/values-image.yaml
@@ -1,5 +1,5 @@
 base:
   image:
     repository: ghcr.io/dbeilin-playground/nginx
-    tag: v1.0.20250904090836-b52b47c
+    tag: v1.0.20250904132852-36a64aa
     pullPolicy: Always


### PR DESCRIPTION
Promote nginx to cand


[View in Kargo UI](https://localhost/project/kargo-savvy/stage/nginx-cand)