### PR TITLE
Promote nginx to prod

### DIFF
--- a/argocd/prod/prod-fra/nginx/values-image.yaml
+++ b/argocd/prod/prod-fra/nginx/values-image.yaml
@@ -1,5 +1,5 @@
 base:
   image:
     repository: ghcr.io/dbeilin-playground/nginx
-    tag: v1.0.20250904085949-8c9c361
+    tag: v1.0.20250904132852-36a64aa
     pullPolicy: Always


### PR DESCRIPTION
Promote nginx to prod


[View in Kargo UI](https://localhost/project/kargo-savvy/stage/nginx-prod)