### PR TITLE
Promote hello-api to cand

### DIFF
--- a/argocd/cand/candidate-fra/hello-api/values-image.yaml
+++ b/argocd/cand/candidate-fra/hello-api/values-image.yaml
@@ -1,5 +1,5 @@
 microservicechart:
   image:
     repository: ghcr.io/dbeilin-playground/hello-api
-    tag: v1.0.20250908093042-2d3756a
+    tag: v1.0.20250908104321-05698ae
     pullPolicy: Always


### PR DESCRIPTION
Promote hello-api to cand


[View in Kargo UI](https://localhost/project/kargo-savvy/stage/hello-api-cand)