### PR TITLE
Promote nginx to cand

### DIFF
--- a/argocd/cand/candidate-fra/nginx/values-image.yaml
+++ b/argocd/cand/candidate-fra/nginx/values-image.yaml
@@ -1,5 +1,5 @@
 microservicechart:
   image:
     repository: ghcr.io/dbeilin-playground/nginx
-    tag: v1.0.20250908093051-2a25b7d
+    tag: v1.0.20250908104326-c2e4ed3
     pullPolicy: Always


### PR DESCRIPTION
Promote nginx to cand


[View in Kargo UI](https://localhost/project/kargo-savvy/stage/nginx-cand)