### PR TITLE
Enable pprof for nginx in cand

### DIFF
--- a/argocd/cand/candidate-fra/nginx/values-image.yaml
+++ b/argocd/cand/candidate-fra/nginx/values-image.yaml
@@ -1,5 +1,5 @@
 microservicechart:
   image:
     repository: ghcr.io/dbeilin-playground/nginx
-    tag: v1.0.20250908120235-38315f7
+    tag: v1.0.20250908120235-38315f7-pprof
     pullPolicy: Always


### PR DESCRIPTION
Enable pprof for nginx in cand


[View in Kargo UI](https://localhost/project/kargo-pprof/stage/nginx-cand-pprof-toggle)