### PR TITLE
Enable pprof for nginx in stg

### DIFF
--- a/argocd/stg/stg-be/nginx/values-image.yaml
+++ b/argocd/stg/stg-be/nginx/values-image.yaml
@@ -1,5 +1,5 @@
 microservicechart:
   image:
     repository: ghcr.io/dbeilin-playground/nginx
-    tag: v1.0.20250909061308-53afb53
+    tag: v1.0.20250909061308-53afb53-pprof
     pullPolicy: Always


### PR DESCRIPTION
Enable pprof for nginx in stg


[View in Kargo UI](https://localhost/project/kargo-pprof/stage/nginx-stg-pprof-toggle)