### PR TITLE
Promote nginx to cand

### DIFF
--- a/argocd/cand/candidate-fra/nginx/values-image.yaml
+++ b/argocd/cand/candidate-fra/nginx/values-image.yaml
@@ -1,5 +1,5 @@
 microservicechart:
   image:
     repository: ghcr.io/dbeilin-playground/nginx
-    tag: v1.0.20250908124436-d7972d2-cherrypick-cherrypick-kuku-2-sep-2025
+    tag: v1.0.20250909061308-53afb53
     pullPolicy: Always


### PR DESCRIPTION
Promote nginx to cand


[View in Kargo UI](https://localhost/project/kargo-savvy/stage/nginx-cand)