### PR TITLE
Promote hello-api to cand

### DIFF
--- a/argocd/cand/candidate-fra/hello-api/values-image.yaml
+++ b/argocd/cand/candidate-fra/hello-api/values-image.yaml
@@ -1,5 +1,5 @@
 microservicechart:
   image:
     repository: ghcr.io/dbeilin-playground/hello-api
-    tag: v1.0.20250909061316-367a82d
+    tag: v1.0.20250909130919-757b0a3
     pullPolicy: Always


### PR DESCRIPTION
Promote hello-api to cand


[View in Kargo UI](https://localhost/project/kargo-savvy/stage/hello-api-cand)