### PR TITLE
Promote nginx to prod

### DIFF
--- a/argocd/prod/prod-fra/nginx/values-image.yaml
+++ b/argocd/prod/prod-fra/nginx/values-image.yaml
@@ -1,5 +1,5 @@
 microservicechart:
   image:
     repository: ghcr.io/dbeilin-playground/nginx
-    tag: v1.0.20250908124436-d7972d2-cherrypick-cherrypick-kuku-2-sep-2025
+    tag: v1.0.20250909132709-2ae5102
     pullPolicy: Always


### PR DESCRIPTION
Promote nginx to prod


[View in Kargo UI](https://localhost/project/kargo-savvy/stage/nginx-prod)